### PR TITLE
Introduce `DEFAULT_TEXT_DOMAIN` constant

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,6 +1,6 @@
 {
     "ignore_php_platform_requirements": {
-        "8.5": true
+        "8.5": false
     },
     "backwardCompatibilityCheck": true
 }

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~3.1.0",
-        "vimeo/psalm": "^6.13.1"
+        "vimeo/psalm": "^6.14.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "727de64c4ceb5989b955b91dc200c415",
+    "content-hash": "ad371b978ee4af33efc07dfb2d6fbbc0",
     "packages": [],
     "packages-dev": [
         {

--- a/src/TranslatorInterface.php
+++ b/src/TranslatorInterface.php
@@ -6,15 +6,17 @@ namespace Laminas\Translator;
 
 interface TranslatorInterface
 {
+    public const DEFAULT_TEXT_DOMAIN = 'default';
+
     /**
      * Translate a message.
      *
      * @param string $message
      * @param string $textDomain
-     * @param string $locale
+     * @param string|null $locale
      * @return string
      */
-    public function translate($message, $textDomain = 'default', $locale = null);
+    public function translate($message, $textDomain = self::DEFAULT_TEXT_DOMAIN, $locale = null);
 
     /**
      * Translate a plural message.
@@ -30,7 +32,7 @@ interface TranslatorInterface
         $singular,
         $plural,
         $number,
-        $textDomain = 'default',
+        $textDomain = self::DEFAULT_TEXT_DOMAIN,
         $locale = null
     );
 }


### PR DESCRIPTION
Adding this constant to the interface will prevent littering implementing codebases with the string literal and provide a way to compare a text domain to the global default when necessary
